### PR TITLE
完善LD_PERLOAD中关于interpreter的描述

### DIFF
--- a/doc/1.3_linux_basic.md
+++ b/doc/1.3_linux_basic.md
@@ -465,7 +465,12 @@ $ LD_PRELOAD=~/libc.so.6 ldd /bin/true
 	/lib64/ld-linux-x86-64.so.2 (0x000055f33bc50000)
 ```
 
-注意，这种方法得根据实际情况来用，大概就是使用的发行版要相同（`interpreter` 相同），上面的例子中两个 libc 是这样的：
+注意，在加载动态链接库时需要使用`ld.so`进行重定位，通常被符号链接到`/lib64/ld-linux-x86-64.so`中。动态链接库在编译时隐式指定`ld.so`的搜索路径，并写入ELF Header的INTERP字段中。从其他发行版直接拷贝已编译的`.so`文件可能会引发`ld.so`搜索路径不正确的问题。相似的，在版本依赖高度耦合的发行版中(如ArchLinux)，版本相差过大也会引发`ld.so`的运行失败。
+
+本地同版本编译后通常不会出现问题。如果有直接拷贝已编译版本的需要，可以对比`interpreter`确定是否符合要求，但是不保证不会失败。
+
+上面的例子中两个 libc 是这样的：
+
 ```
 $ file /lib/x86_64-linux-gnu/libc-2.23.so 
 /lib/x86_64-linux-gnu/libc-2.23.so: ELF 64-bit LSB shared object, x86-64, version 1 (GNU/Linux), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=088a6e00a1814622219f346b41e775b8dd46c518, for GNU/Linux 2.6.32, stripped


### PR DESCRIPTION
原文的描述没有提到具体原因。经过查阅，以及过去的实践，这是由于ld装载导致的。

ld装载是一个很复杂的事情，所以只能简单描述一下。